### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/rob599_basic/CMakeLists.txt
+++ b/rob599_basic/CMakeLists.txt
@@ -271,6 +271,8 @@ add_executable(action_client
   src/action_client.cpp
 )
 
+add_dependencies(service_client ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
 target_link_libraries(action_client
   ${catkin_LIBRARIES}
 )


### PR DESCRIPTION
In the #setup channel, a student mentioned running into issues with dependencies. The TA mentioned adding  `add_dependencies(service_client ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})` to line 273 of the CMakeLists.txt file for rob599_basic. Here is a commit with the added line.