### PR TITLE
Replace test_requires with extras_require

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ qtcreator-*
 CATKIN_IGNORE
 rob599_basic/.vscode/c_cpp_properties.json
 rob599_basic/.vscode/settings.json
-rob599_basic/resource/rob599_basic
 rob599_basic/test/test_copyright.py
 rob599_basic/test/test_flake8.py
 rob599_basic/test/test_pep257.py

--- a/rob599_basic/setup.py
+++ b/rob599_basic/setup.py
@@ -1,4 +1,5 @@
 from setuptools import find_packages, setup
+import rclpy
 
 package_name = 'rob599_basic'
 

--- a/rob599_basic/setup.py
+++ b/rob599_basic/setup.py
@@ -1,5 +1,4 @@
 from setuptools import find_packages, setup
-import rclpy
 
 package_name = 'rob599_basic'
 

--- a/rob599_basic/setup.py
+++ b/rob599_basic/setup.py
@@ -14,6 +14,7 @@ setup(
         ('share/' + package_name, ['package.xml']),
     ],
     install_requires=['setuptools'],
+    extras_require={"test": ["pytest"]},
     zip_safe=True,
 
     maintainer='Bill Smart',
@@ -21,7 +22,7 @@ setup(
     description='ROS 2 examples for ROB 499/599: Robot Software Frameworks',
     license='BSD-3-Clause',
 
-    tests_require=['pytest'],
+    
     entry_points={
         'console_scripts': [
             # A Basic node that does nothing useful.


### PR DESCRIPTION
test_requires was deprecated a while ago, replaced it with extras_require to get rid of warnings while building.